### PR TITLE
Stop using '-f' with tag

### DIFF
--- a/packer-drone-packer-x86_64.json
+++ b/packer-drone-packer-x86_64.json
@@ -20,7 +20,6 @@
         "type": "docker-tag",
         "repository": "vtolstov/drone-packer",
         "tag": "latest",
-        "force": true
       },
       "docker-push"
     ]


### PR DESCRIPTION
Overwriting tags is done by default since Docker v1.10.0, ref
https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag

This fixes using v1.12.0 as the '-f' option was removed:

```
Build 'docker' errored: 1 error(s) occurred:

* Post-processor failed: Error tagging image: exit status 125
Stderr: unknown shorthand flag: 'f' in -f
See 'docker tag --help'.
```